### PR TITLE
Fix glitch with FlexConv gaussian scale numerical instability.

### DIFF
--- a/ckconv/nn/flexconv.py
+++ b/ckconv/nn/flexconv.py
@@ -294,7 +294,7 @@ def gaussian_mask(
     # mask.shape = [1, 1, Y, X] in 2D or [1, 1, X] in 1D
     return torch.exp(
         -0.5
-        * ((1.0 / mask_width_param * (kernel_pos - mask_mean_param)) ** 2).sum(
+        * (1.0 / (mask_width_param ** 2 + 1e-8) * (kernel_pos - mask_mean_param) ** 2).sum(
             1, keepdim=True
         )
     )


### PR DESCRIPTION
## Description

I encountered an issue where the FlexConv Gaussian kernel mask could introduce `inf` gradients when the learned scale would approach a value of zero. This leads to NaN losses and crashes the logging of validation logits.

The fix is to slightly rewrite the `gaussian_mask` function to add an epsilon factor to the scale of the Gaussian. To do this, I also had to pull in the square over the scale to the fraction.

## Results

### Original code, with the issue

Command (matches the one in experiments README): 

```
python main.py train.batch_size=64 train.epochs=350 dataset.augment=True dataset.name=CIFAR10 dataset.data_type=default device=cuda net.dropout=0.1 net.dropout_in=0 net.type=ResNet net.norm=BatchNorm net.no_blocks=4 net.no_hidden=140 net.block.type=S4 net.block.prenorm=True net.nonlinearity=GELU kernel.type=MAGNet kernel.omega_0=4231.568793085858 kernel.no_hidden=32 kernel.no_layers=3 kernel.size=33 kernel.chang_initialize=True mask.dynamic_cropping=true mask.init_value=0.75 mask.learn_mean=false mask.temperature=0 mask.threshold=0.1 mask.type=gaussian conv.type=SeparableFlexConv conv.use_fft=False scheduler.name=cosine scheduler.warmup_epochs=5 optimizer.name=AdamW optimizer.mask_lr_ratio=0.1 optimizer.weight_decay=0.0001 optimizer.lr=0.02 seed=0
```

Error:

```
Traceback (most recent call last):
  File "/tudelft.net/staff-bulk/ewi/insy/VisionLab/robertjanbruin/code/scale-flexconv/main.py", line 170, in <module>
    main()
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/hydra/main.py", line 90, in decorated_main
    _run_hydra(
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/hydra/_internal/utils.py", line 389, in _run_
hydra
    _run_app(
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/hydra/_internal/utils.py", line 452, in _run_
app
    run_and_report(
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/hydra/_internal/utils.py", line 296, in run_a
nd_report
    raise ex
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/hydra/_internal/utils.py", line 213, in run_a
nd_report
    return func()
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/hydra/_internal/utils.py", line 453, in <lamb
da>
    lambda: hydra.run(
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/hydra/_internal/hydra.py", line 132, in run
    _ = ret.return_value
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/hydra/core/utils.py", line 260, in return_val
ue
    raise self._return_value
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/hydra/core/utils.py", line 186, in run_job
    ret.return_value = task_function(task_cfg)
  File "/tudelft.net/staff-bulk/ewi/insy/VisionLab/robertjanbruin/code/scale-flexconv/main.py", line 130, in main
    trainer.fit(model=model, datamodule=datamodule)
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/trainer/trainer.py", line 7
70, in fit
    self._call_and_handle_interrupt(
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/trainer/trainer.py", line 7
23, in _call_and_handle_interrupt
    return trainer_fn(*args, **kwargs)
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/trainer/trainer.py", line 8
11, in _fit_impl
    results = self._run(model, ckpt_path=self.ckpt_path)
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/trainer/trainer.py", line 1
236, in _run
    results = self._run_stage()
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/trainer/trainer.py", line 1
323, in _run_stage
    return self._run_train()
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/trainer/trainer.py", line 1
353, in _run_train
    self.fit_loop.run()
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/loops/base.py", line 204, i
n run
    self.advance(*args, **kwargs)
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/loops/fit_loop.py", line 26
9, in advance
    self._outputs = self.epoch_loop.run(self._data_fetcher)
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/loops/base.py", line 205, i
n run
    self.on_advance_end()
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/loops/fit_loop.py", line 26
9, in advance
    self._outputs = self.epoch_loop.run(self._data_fetcher)
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/loops/base.py", line 205, in run
    self.on_advance_end()
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/loops/epoch/training_epoch_
loop.py", line 255, in on_advance_end
    self._run_validation()
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/loops/epoch/training_epoch_
loop.py", line 309, in _run_validation
    self.val_loop.run()
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/loops/base.py", line 211, i
n run
    output = self.on_run_end()
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/loops/dataloader/evaluation_loop.py", line 188, in on_run_end
    self._evaluation_epoch_end(self._outputs)
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/loops/dataloader/evaluation_loop.py", line 315, in _evaluation_epoch_end
    self.trainer._call_lightning_module_hook("validation_epoch_end", output_or_outputs)
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/pytorch_lightning/trainer/trainer.py", line 1595, in _call_lightning_module_hook
    output = fn(*args, **kwargs)
  File "/tudelft.net/staff-bulk/ewi/insy/VisionLab/robertjanbruin/code/scale-flexconv/models/lightning_wrappers.py", line 263, in validation_epoch_end
    "val/logits": wandb.Histogram(flattened_logits.to("cpu")),
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/wandb/sdk/data_types/histogram.py", line 77, in __init__
    self.histogram, self.bins = np.histogram(sequence, bins=num_bins)
  File "<__array_function__ internals>", line 180, in histogram
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/numpy/lib/histograms.py", line 793, in histogram
    bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/numpy/lib/histograms.py", line 426, in _get_bin_edges
    first_edge, last_edge = _get_outer_edges(a, range)
  File "/home/nfs/robertjanbruin/bulk-home/envs/scale-flexconv/lib/python3.9/site-packages/numpy/lib/histograms.py", line 323, in _get_outer_edges
    raise ValueError(
ValueError: autodetected range of [nan, nan] is not finite
```

### With fix

Command: 

```
python main.py train.batch_size=64 train.epochs=350 dataset.augment=True dataset.name=CIFAR10 dataset.data_type=default device=cuda net.dropout=0.1 net.dropout_in=0 net.type=ResNet net.norm=BatchNorm net.no_blocks=4 net.no_hidden=140 net.block.type=S4 net.block.prenorm=True net.nonlinearity=GELU kernel.type=MAGNet kernel.omega_0=4231.568793085858 kernel.no_hidden=32 kernel.no_layers=3 kernel.size=33 kernel.chang_initialize=True mask.dynamic_cropping=true mask.init_value=0.75 mask.learn_mean=false mask.temperature=0 mask.threshold=0.1 mask.type=gaussian conv.type=SeparableFlexConv conv.use_fft=False scheduler.name=cosine scheduler.warmup_epochs=5 optimizer.name=AdamW optimizer.mask_lr_ratio=0.1 optimizer.weight_decay=0.0001 optimizer.lr=0.02 seed=0
```

Results for `test/acc` over three different seeds: `0.9279, 0.9187, 0.908`.